### PR TITLE
Update CODEOWNERS - reduce to @camaraproject/admins

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,7 +6,7 @@
 
 # These are the default owners for the whole content of this repository. The default owners are automatically added as reviewers when you open a pull request, unless different owners are specified in the file.
 # Replace the following line with "* @codeowner1 @codeowner2 @codeowner3" with the individual codeowner user names (the CODEOWNER file is the source of truth for the sub project codeowner team
-* @camaraproject/admins @camaraproject/release-management_codeowners @camaraproject/marketing_codeowners
+* @camaraproject/admins
 
 # Owners of the CODEOWNER and Maintainer.md files are the admins of CAMARA (to allow them to keep the teams within the CAMARA organization in sync in case of changes)
 /CODEOWNERS @camaraproject/admins


### PR DESCRIPTION

To be able to use the .github repository for administrative workflows and similar, it is necessary to restrict the codeowner ship to the admin team of CAMARA. 